### PR TITLE
binary_name was renamed to binary in the archive configuration

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -55,7 +55,7 @@ By default GoReleaser will build the **main.go** file located in your current di
 # goreleaser.yml
 # Build customization
 build:
-  binary_name: drum-roll
+  binary: drum-roll
   goos:
     - windows
     - darwin
@@ -66,7 +66,7 @@ build:
 
 This configuration specifies the build operating systems to Windows, Linux and MacOS using 64bit architecture, the name of the binaries is `drum-roll`.
 
-GoReleaser will then archive the result binaries of each Os/Arch into a separate file. The default format is `{{.BinaryName}}_{{.Os}}_{{.Arch}}`.
+GoReleaser will then archive the result binaries of each Os/Arch into a separate file. The default format is `{{ .Binary }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}`.
 You can change the archives name and format. You can also replace the OS and the Architecture with your own.
 Another useful feature is to add files to archives, this is very useful for integrating assets like resource files.
 
@@ -75,7 +75,7 @@ Another useful feature is to add files to archives, this is very useful for inte
 # Build customization
 build:
   main: main.go
-  binary_name: drum-roll
+  binary: drum-roll
   goos:
     - windows
     - darwin
@@ -163,7 +163,7 @@ build:
   main: ./cmd/main.go
 
   # Name of the binary. Default is the name of the project directory.
-  binary_name: program
+  binary: program
 
   # Custom ldflags.
   # Default is `-s -w`
@@ -191,12 +191,12 @@ archive:
   # You can change the name of the archive.
   # This is parsed with Golang template engine and the following variables
   # are available:
-  # - BinaryName
+  # - Binary
   # - Version
   # - Os
   # - Arch
-  # The default is `{{.BinaryName}}_{{.Os}}_{{.Arch}}`
-  name_template: "{{.BinaryName}}_{{.Version}}_{{.Os}}_{{.Arch}}"
+  # The default is `{{ .Binary }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}`
+  name_template: "{{.Binary}}_{{.Version}}_{{.Os}}_{{.Arch}}"
 
   # Archive format. Valid options are `tar.gz` and `zip`.
   # Default is `tar.gz`


### PR DESCRIPTION
Looks like https://github.com/goreleaser/goreleaser/commit/b3fa5cfc192c17fa3cafdcd99d72203c37f3ac99 hasn't yet made it in here :) This should fix that.